### PR TITLE
DAOS-5243 build: add h5daos_test_metadata_parallel

### DIFF
--- a/hdf5-vol-daos.spec
+++ b/hdf5-vol-daos.spec
@@ -37,7 +37,7 @@
 
 Name:    hdf5-vol-daos
 Version: %{vol_major}.%{vol_minor}.%{vol_bugrelease}%{?vol_prerelease:~%{vol_prerelease}}
-Release: 1%{?commit:.git%{shortcommit}}%{?dist}
+Release: 2%{?commit:.git%{shortcommit}}%{?dist}
 Summary: A Multi-purpose, Application-Centric, Scalable I/O Proxy Application
 
 License: GPL
@@ -199,10 +199,10 @@ done
 %endif
 
 %changelog
-* Mon Feb 08 2021 Jonathan Martinez Montes <jonathan.martinez.montes@intel.com> - 1.1.0~rc2
+* Mon Feb 08 2021 Jonathan Martinez Montes <jonathan.martinez.montes@intel.com> - 1.1.0~rc2-2
 - Add test h5daos_test_metadata_parallel
 
-* Wed Feb 03 2021 Maureen Jean <maureen.jean@intel.com> - 1.1.0~rc2
+* Wed Feb 03 2021 Maureen Jean <maureen.jean@intel.com> - 1.1.0~rc2-1
 - Update hdf5-vol v1.1.0rc2 and vol_tests v0.9.1
 
 * Fri Jan 29 2021 Maureen Jean <maureen.jean@intel.com> - 1.1.0~rc1

--- a/hdf5-vol-daos.spec
+++ b/hdf5-vol-daos.spec
@@ -153,7 +153,8 @@ do
   mkdir -p ${RPM_BUILD_ROOT}%{_libdir}/hdf5_vol_daos/$mpi/tests/
   for x in h5_test_testhdf5 h5vl_test h5_partest_t_bigio h5_partest_testphdf5 \
            h5vl_test_parallel h5_partest_t_shapesame h5daos_test_map \
-           h5daos_test_map_parallel h5daos_test_oclass
+           h5daos_test_map_parallel h5daos_test_oclass \
+           h5daos_test_metadata_parallel
   do
     install -m 0755 $mpi/bin/${x} ${RPM_BUILD_ROOT}%{_libdir}/hdf5_vol_daos/$mpi/tests/
   done
@@ -198,6 +199,9 @@ done
 %endif
 
 %changelog
+* Mon Feb 08 2021 Jonathan Martinez Montes <jonathan.martinez.montes@intel.com> - 1.1.0~rc2
+- Add test h5daos_test_metadata_parallel
+
 * Wed Feb 03 2021 Maureen Jean <maureen.jean@intel.com> - 1.1.0~rc2
 - Update hdf5-vol v1.1.0rc2 and vol_tests v0.9.1
 


### PR DESCRIPTION
SRS-35 requires to tests the async API added by the HDF group. This
PR adds the h5daos_test_metadata_parallel that is currently not
included in the rpms.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>